### PR TITLE
Add December 2022 to quarterly meeting title

### DIFF
--- a/docs/events/wg_workshops/2022-12-05-december-meeting/index.md
+++ b/docs/events/wg_workshops/2022-12-05-december-meeting/index.md
@@ -1,4 +1,4 @@
-# RSE TRE Community Quarterly Meeting
+# RSE TRE Community Quarterly Meeting (December 2022)
 
 ```{toctree}
 :maxdepth: 1


### PR DESCRIPTION
This ensure the index page shows a more meaningful title