### PR TITLE
Short title for Newcastle Declaration in header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 :maxdepth: 1
 :hidden: true
 
-Newcastle Commitment to Open Collaboration <newcastle-commitment/index>
+Newcastle Commitment <newcastle-commitment/index>
 events/index
 background/index
 vision/index

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 :maxdepth: 1
 :hidden: true
 
-newcastle-commitment/index
+Newcastle Commitment to Open Collaboration <newcastle-commitment/index>
 events/index
 background/index
 vision/index


### PR DESCRIPTION
Using the full title in the header/nav-bar takes up too much space. Optionally we could shorten it further to just `Newcastle Declaration`.